### PR TITLE
#45 adding support for recursively resolving inline modular content

### DIFF
--- a/src/test/resources/customTemplateLocation/item.template
+++ b/src/test/resources/customTemplateLocation/item.template
@@ -1,1 +1,1 @@
-<custom th:text="${model.messageText}"></custom>
+<custom th:utext="${model.messageText}"></custom>


### PR DESCRIPTION
Making a PR for visibility, although I'm going to merge it to get it into a snapshot build.  This is in relation to issue #45 

This change allows you to nest <object> references inside of inline modular content resolution.  Any resolver, whether code based, or template based works.

This only realistically works if you have a depth query parameter set to greater than 1.  The implementation also ensures that no cyclic loop is resolved (and this is unit tested).

I also tested a local build of this with an internal app, and it works.