### PR TITLE
#53 Implement optional retry logic for CDN failures

### DIFF
--- a/src/main/java/com/kenticocloud/delivery/DeliveryOptions.java
+++ b/src/main/java/com/kenticocloud/delivery/DeliveryOptions.java
@@ -37,6 +37,7 @@ public class DeliveryOptions {
     String previewApiKey;
     boolean usePreviewApi = false;
     boolean waitForLoadingNewContent = false;
+    int retryAttempts = 0;
 
     /**
      * Constructs an empty settings instance of {@link DeliveryOptions}.
@@ -182,5 +183,21 @@ public class DeliveryOptions {
      */
     public void setWaitForLoadingNewContent(boolean waitForLoadingNewContent) {
         this.waitForLoadingNewContent = waitForLoadingNewContent;
+    }
+
+    /**
+     * Get the number of times the client will retry to connect to the Kentico Cloud api on failures per request.
+     * @return The number of retry attempts on failed responses from Kentico Cloud
+     */
+    public int getRetryAttempts() {
+        return retryAttempts;
+    }
+
+    /**
+     * Sets the number of times the client will try to connect to the Kentico Cloud api on failures per request.
+     * @param retryAttempts The number of retry attempts.
+     */
+    public void setRetryAttempts(int retryAttempts) {
+        this.retryAttempts = retryAttempts;
     }
 }


### PR DESCRIPTION
Here is an implementation for retrying requests on failures.  By default, no retries are performed.  When a retry is performed, there is a binary backoff based on 100ms to the API.

Could you guys give this a quick glance?