### PR TITLE
#48 When querying getItem or getItems with a strongly typed class, automatically add a query filter for system type

### DIFF
--- a/src/main/java/com/kenticocloud/delivery/DeliveryClient.java
+++ b/src/main/java/com/kenticocloud/delivery/DeliveryClient.java
@@ -441,7 +441,9 @@ public class DeliveryClient {
                 .findAny();
         if (!any.isPresent()) {
             String contentType = stronglyTypedContentItemConverter.getContentType(tClass);
-            params.add(new BasicNameValuePair("system.type", contentType));
+            if (contentType != null) {
+                params.add(new BasicNameValuePair("system.type", contentType));
+            }
         }
     }
 

--- a/src/main/java/com/kenticocloud/delivery/StronglyTypedContentItemConverter.java
+++ b/src/main/java/com/kenticocloud/delivery/StronglyTypedContentItemConverter.java
@@ -63,6 +63,13 @@ public class StronglyTypedContentItemConverter {
         logger.debug("Registered type for {}", clazz.getSimpleName());
     }
 
+    protected String getContentType(Class tClass) {
+        if (classToContentTypeMapping.containsKey(tClass)) {
+            return classToContentTypeMapping.get(tClass);
+        }
+        return null;
+    }
+
     protected void registerInlineContentItemsResolver(InlineContentItemsResolver resolver) {
         typeToInlineResolverMapping.put(resolver.getType(), resolver);
     }

--- a/src/test/java/com/kenticocloud/delivery/DeliveryClientTest.java
+++ b/src/test/java/com/kenticocloud/delivery/DeliveryClientTest.java
@@ -484,11 +484,20 @@ public class DeliveryClientTest extends LocalServerTestBase {
 
         this.serverBootstrap.registerHandler(
                 String.format("/%s/%s", projectId, "items/on_roasts"),
-                (request, response, context) -> response.setEntity(
-                        new InputStreamEntity(
-                                this.getClass().getResourceAsStream("SampleContentItem.json")
-                        )
-                ));
+                (request, response, context) -> {
+                    String uri = String.format("http://testserver%s", request.getRequestLine().getUri());
+
+                    List<NameValuePair> nameValuePairs =
+                            URLEncodedUtils.parse(URI.create(uri), Charset.defaultCharset());
+                    Assert.assertFalse(nameValuePairs.stream()
+                            .anyMatch(nameValuePair -> nameValuePair.getName().equals("system.type")));
+
+                    response.setEntity(
+                            new InputStreamEntity(
+                                    this.getClass().getResourceAsStream("SampleContentItem.json")
+                            )
+                    );
+                });
         HttpHost httpHost = this.start();
         DeliveryClient client = new DeliveryClient(projectId);
         client.registerType("article", ArticleItem.class);

--- a/src/test/java/com/kenticocloud/delivery/DeliveryClientTest.java
+++ b/src/test/java/com/kenticocloud/delivery/DeliveryClientTest.java
@@ -505,6 +505,90 @@ public class DeliveryClientTest extends LocalServerTestBase {
     }
 
     @Test
+    public void testGetStronglyTypedItemAutomaticallyAddsSystemType() throws Exception {
+        String projectId = "02a70003-e864-464e-b62c-e0ede97deb8c";
+
+        this.serverBootstrap.registerHandler(
+                String.format("/%s/%s", projectId, "items/on_roasts"),
+                (request, response, context) -> {
+                    String uri = String.format("http://testserver%s", request.getRequestLine().getUri());
+
+                    List<NameValuePair> nameValuePairs =
+                            URLEncodedUtils.parse(URI.create(uri), Charset.defaultCharset());
+                    Assert.assertEquals(1, nameValuePairs.stream()
+                            .filter(nameValuePair -> nameValuePair.getName().equals("system.type"))
+                            .count());
+
+                    Map<String, String> params = convertNameValuePairsToMap(nameValuePairs);
+
+                    Assert.assertTrue(params.containsKey("system.type"));
+                    Assert.assertEquals("article", params.get("system.type"));
+
+                    response.setEntity(
+                            new InputStreamEntity(
+                                    this.getClass().getResourceAsStream("SampleContentItem.json")
+                            )
+                    );
+                });
+        HttpHost httpHost = this.start();
+        DeliveryClient client = new DeliveryClient(projectId);
+        client.registerType("article", ArticleItem.class);
+
+        //modify default baseurl to point to test server, this is private so using reflection
+        String testServerUri = httpHost.toURI() + "/%s";
+        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
+        deliveryOptionsField.setAccessible(true);
+        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+
+        ArticleItem itemObj = client.getItem("on_roasts", ArticleItem.class);
+        Assert.assertNotNull(itemObj);
+    }
+
+    @Test
+    public void testGetStronglyTypedItemAutomaticallyDoesNotSentSystemTypeWhenAdded() throws Exception {
+        String projectId = "02a70003-e864-464e-b62c-e0ede97deb8c";
+
+        this.serverBootstrap.registerHandler(
+                String.format("/%s/%s", projectId, "items/on_roasts"),
+                (request, response, context) -> {
+                    String uri = String.format("http://testserver%s", request.getRequestLine().getUri());
+
+                    List<NameValuePair> nameValuePairs =
+                            URLEncodedUtils.parse(URI.create(uri), Charset.defaultCharset());
+                    Assert.assertEquals(1, nameValuePairs.stream()
+                            .filter(nameValuePair -> nameValuePair.getName().equals("system.type"))
+                            .count());
+                    Map<String, String> params = convertNameValuePairsToMap(nameValuePairs);
+
+                    Assert.assertTrue(params.containsKey("system.type"));
+                    Assert.assertEquals("customVal", params.get("system.type"));
+
+                    response.setEntity(
+                            new InputStreamEntity(
+                                    this.getClass().getResourceAsStream("SampleContentItem.json")
+                            )
+                    );
+                });
+        HttpHost httpHost = this.start();
+        DeliveryClient client = new DeliveryClient(projectId);
+        client.registerType("article", ArticleItem.class);
+
+        //modify default baseurl to point to test server, this is private so using reflection
+        String testServerUri = httpHost.toURI() + "/%s";
+        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
+        deliveryOptionsField.setAccessible(true);
+        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+
+        ArticleItem itemObj = client.getItem(
+                "on_roasts",
+                ArticleItem.class,
+                DeliveryParameterBuilder.params()
+                        .filterEquals("system.type", "customVal")
+                        .build());
+        Assert.assertNotNull(itemObj);
+    }
+
+    @Test
     public void testGetStronglyTypedItemByRegisteringMapping() throws Exception {
         String projectId = "02a70003-e864-464e-b62c-e0ede97deb8c";
 
@@ -654,11 +738,22 @@ public class DeliveryClientTest extends LocalServerTestBase {
 
         this.serverBootstrap.registerHandler(
                 String.format("/%s/%s", projectId, "items"),
-                (request, response, context) -> response.setEntity(
-                        new InputStreamEntity(
-                                this.getClass().getResourceAsStream("SampleContentItemList.json")
-                        )
-                ));
+                (request, response, context) -> {
+                    String uri = String.format("http://testserver%s", request.getRequestLine().getUri());
+
+                    List<NameValuePair> nameValuePairs =
+                            URLEncodedUtils.parse(URI.create(uri), Charset.defaultCharset());
+                    Map<String, String> params = convertNameValuePairsToMap(nameValuePairs);
+
+                    Assert.assertTrue(params.containsKey("system.type"));
+                    Assert.assertEquals("article", params.get("system.type"));
+
+                    response.setEntity(
+                            new InputStreamEntity(
+                                    this.getClass().getResourceAsStream("SampleContentItemList.json")
+                            )
+                    );
+                });
         HttpHost httpHost = this.start();
         DeliveryClient client = new DeliveryClient(projectId);
 


### PR DESCRIPTION
This is a convenience enhancement to automatically add the system.type query parameter if it's possible by introspecting the type requested.

Internally, we have been finding many times we are manually adding this to our client request parameters, as sometimes certain queries will return content types that somewhat map to the objects we request, and are not wanted.