### PR TITLE
Feature/non blocking client

### DIFF
--- a/delivery/build.gradle
+++ b/delivery/build.gradle
@@ -53,7 +53,8 @@ dependencies {
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.8.9'
     compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.4.0'
 
-    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'
+    compile group: 'org.asynchttpclient', name: 'async-http-client', version: '2.5.3'
+    compile group: 'org.asynchttpclient', name: 'async-http-client-extras-rxjava2', version: '2.5.3'
 
     compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.3'
 
@@ -64,6 +65,7 @@ dependencies {
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3', classifier: 'tests'
+    testCompile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
 
 }

--- a/delivery/src/main/java/com/kenticocloud/delivery/AsyncCacheManager.java
+++ b/delivery/src/main/java/com/kenticocloud/delivery/AsyncCacheManager.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2017
+ * Copyright (c) 2018
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,21 +25,17 @@
 package com.kenticocloud.delivery;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.reactivex.Completable;
+import io.reactivex.Maybe;
 
-import java.io.IOException;
+import java.util.List;
 
-/**
- * This callback is provided to {@link CacheManager} implementations to invoke on a cache miss.
- *
- * @see CacheManager
- */
-public interface HttpRequestExecutor {
+// TODO: JavaDoc
+public interface AsyncCacheManager {
 
-    /**
-     * Return a response from the KenticoCloud API.
-     *
-     * @return              The JSON response from the KenticoCloud API
-     * @throws IOException  On an exception calling the KenticoCloud API, this should be rethrown.
-     */
-    JsonNode execute() throws IOException;
+    // TODO: JavaDoc
+    Maybe<JsonNode> get(final String url);
+
+    // TODO: JavaDoc
+    Completable put(final String url, JsonNode jsonNode, List<ContentItem> containedContentItems);
 }

--- a/delivery/src/main/java/com/kenticocloud/delivery/AsyncDeliveryClient.java
+++ b/delivery/src/main/java/com/kenticocloud/delivery/AsyncDeliveryClient.java
@@ -1,0 +1,521 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.kenticocloud.delivery;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.JSR310Module;
+import com.kenticocloud.delivery.template.TemplateEngineConfig;
+import io.reactivex.Flowable;
+import io.reactivex.Maybe;
+import lombok.extern.slf4j.Slf4j;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.Request;
+import org.asynchttpclient.Response;
+import org.asynchttpclient.extras.rxjava2.DefaultRxHttpClient;
+import org.asynchttpclient.extras.rxjava2.RxHttpClient;
+import org.reactivestreams.Publisher;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static org.asynchttpclient.Dsl.*;
+
+// TODO: add JavaDoc
+
+// TODO: immutable delivery options
+
+// TODO: documentation about closing the client
+
+@Slf4j
+public class AsyncDeliveryClient implements Closeable {
+
+    private static String sdkId;
+
+    static {
+        try {
+            Properties buildProps = new Properties();
+            buildProps.load(AsyncDeliveryClient.class.getResourceAsStream("build.properties"));
+            String repositoryHost = buildProps.getProperty("Repository-Host");
+            String version = buildProps.getProperty("Implementation-Version");
+            String packageId = buildProps.getProperty("Package-Id");
+            repositoryHost = repositoryHost == null ? "localBuild" : repositoryHost;
+            version = version == null ? "0.0.0" : version;
+            packageId = packageId == null ? "com.kenticocloud:delivery" : packageId;
+            sdkId = String.format(
+                    "%s;%s;%s",
+                    repositoryHost,
+                    packageId,
+                    version);
+            log.info("SDK ID: {}", sdkId);
+        } catch (IOException e) {
+            log.info("Jar manifest read error, setting developer build SDK ID");
+            sdkId = "localBuild;com.kenticocloud:delivery;0.0.0";
+        }
+    }
+
+    private static final String ITEMS = "items";
+    private static final String TYPES = "types";
+    private static final String ELEMENTS = "elements";
+    private static final String TAXONOMIES = "taxonomies";
+
+    private static final String URL_CONCAT = "%s/%s";
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+    private DeliveryOptions deliveryOptions;
+
+    private ContentLinkUrlResolver contentLinkUrlResolver;
+    private BrokenLinkUrlResolver brokenLinkUrlResolver;
+    private RichTextElementResolver richTextElementResolver = new DelegatingRichTextElementResolver();
+    private StronglyTypedContentItemConverter stronglyTypedContentItemConverter =
+            new StronglyTypedContentItemConverter();
+    private TemplateEngineConfig templateEngineConfig;
+
+    private AsyncHttpClient asyncHttpClient;
+    private RxHttpClient rxHttpClient;
+
+    // TODO: implement an async/non-blocking cache manager
+    private CacheManager cacheManager = (requestUri, executor) -> executor.execute();
+
+    @SuppressWarnings("WeakerAccess")
+    public AsyncDeliveryClient(DeliveryOptions deliveryOptions) {
+        this(deliveryOptions, new TemplateEngineConfig());
+    }
+
+    @SuppressWarnings({"ResultOfMethodCallIgnored", "WeakerAccess"})
+    public AsyncDeliveryClient(DeliveryOptions deliveryOptions, TemplateEngineConfig templateEngineConfig) {
+        if (deliveryOptions == null) {
+            throw new IllegalArgumentException("The Delivery options object is not specified.");
+        }
+        if (deliveryOptions.getProjectId() == null || deliveryOptions.getProjectId().isEmpty()) {
+            throw new IllegalArgumentException("Kentico Cloud project identifier is not specified.");
+        }
+        try {
+            UUID.fromString(deliveryOptions.getProjectId());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Provided string is not a valid project identifier (%s).  Have you accidentally passed " +
+                                    "the Preview API key instead of the project identifier?",
+                            deliveryOptions.getProjectId()),
+                    e);
+        }
+        if (deliveryOptions.isUsePreviewApi() &&
+                (deliveryOptions.getPreviewApiKey() == null || deliveryOptions.getPreviewApiKey().isEmpty())) {
+            throw new IllegalArgumentException("The Preview API key is not specified.");
+        }
+        if (deliveryOptions.isUsePreviewApi() && deliveryOptions.getProductionApiKey() != null) {
+            throw new IllegalArgumentException("Cannot provide both a preview API key and a production API key.");
+        }
+        if (deliveryOptions.getRetryAttempts() < 0) {
+            throw new IllegalArgumentException("Cannot retry connections less than 0 times.");
+        }
+        this.deliveryOptions = deliveryOptions;
+
+        if (templateEngineConfig != null) {
+            templateEngineConfig.init();
+            this.templateEngineConfig = templateEngineConfig;
+        }
+        reconfigureDeserializer();
+
+        // TODO: max connections (20)
+        asyncHttpClient = asyncHttpClient(config());
+        rxHttpClient = new DefaultRxHttpClient(asyncHttpClient);
+    }
+
+    @SuppressWarnings("unused")
+    public AsyncDeliveryClient(String projectId) {
+        this(new DeliveryOptions(projectId));
+    }
+
+    @SuppressWarnings("unused")
+    public AsyncDeliveryClient(String projectId, String previewApiKey) {
+        this(new DeliveryOptions(projectId, previewApiKey));
+    }
+
+    public Maybe<ContentItemsListingResponse> getItems() {
+        return getItems(Collections.emptyList());
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public Maybe<ContentItemsListingResponse> getItems(List<NameValuePair> params) {
+        return executeRequest(ITEMS, params, ContentItemsListingResponse.class)
+                .map(contentItemsListingResponse ->
+                        contentItemsListingResponse
+                                .setStronglyTypedContentItemConverter(stronglyTypedContentItemConverter))
+                .map(response -> {
+                    createRichTextElementConverter().process(response.items);
+                    return response;
+                });
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public <T> Maybe<List<T>> getItems(Class<T> tClass, List<NameValuePair> params) {
+        return getItems(addTypeParameterIfNecessary(tClass, params))
+                .map(contentItemsListingResponse -> contentItemsListingResponse.castTo(tClass));
+    }
+
+    @SuppressWarnings("unused")
+    public Maybe<ContentItemResponse> getItem(String contentItemCodename) {
+        return getItem(contentItemCodename, Collections.emptyList());
+    }
+
+    @SuppressWarnings("unused")
+    public <T> Maybe<List<T>> getItems(Class<T> tClass) {
+        return getItems(tClass, Collections.emptyList());
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public <T> Maybe<Page<T>> getPageOfItems(Class<T> tClass, List<NameValuePair> params) {
+        return getItems(params)
+                .map(response ->
+                        response.setStronglyTypedContentItemConverter(stronglyTypedContentItemConverter))
+                .map(response -> new Page<>(response, tClass));
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public <T> Maybe<Page<T>> getNextPage(Page<T> currentPage) {
+        final Pagination pagination = currentPage.getPagination();
+        if (pagination.getNextPage() == null || pagination.getNextPage().isEmpty()) {
+            return Maybe.empty();
+        }
+
+        return executeRequest(pagination.getNextPage(), ContentItemsListingResponse.class)
+                .map(response -> response.setStronglyTypedContentItemConverter(stronglyTypedContentItemConverter))
+                .map(response -> {
+                    createRichTextElementConverter().process(response.items);
+                    return response;
+                })
+                .map(response -> new Page<>(response, currentPage.getType()));
+    }
+
+    @SuppressWarnings("unused")
+    public <T> Maybe<T> getItem(String contentItemCodename, Class<T> tClass) {
+        return getItem(contentItemCodename, tClass, Collections.emptyList());
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public Maybe<ContentItemResponse> getItem(String contentItemCodename, List<NameValuePair> params) {
+        final String apiCall = String.format(URL_CONCAT, ITEMS, contentItemCodename);
+        return executeRequest(apiCall, params, ContentItemResponse.class)
+                .map(response ->
+                        response.setStronglyTypedContentItemConverter(stronglyTypedContentItemConverter))
+                .map(response -> {
+                    createRichTextElementConverter().process(response.item);
+                    return response;
+                });
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public <T> Maybe<T> getItem(String contentItemCodename, Class<T> tClass, List<NameValuePair> params) {
+        return getItem(contentItemCodename, addTypeParameterIfNecessary(tClass, params))
+                .map(contentItemResponse -> contentItemResponse.castTo(tClass));
+    }
+
+    public Maybe<ContentTypesListingResponse> getTypes() {
+        return getTypes(Collections.emptyList());
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public Maybe<ContentTypesListingResponse> getTypes(List<NameValuePair> params) {
+        return executeRequest(TYPES, params, ContentTypesListingResponse.class);
+    }
+
+    public Maybe<ContentType> getType(String contentTypeCodeName) {
+        final String apiCall = String.format(URL_CONCAT, TYPES, contentTypeCodeName);
+        return executeRequest(apiCall, Collections.emptyList(), ContentType.class);
+    }
+
+    @SuppressWarnings("unused")
+    public Maybe<Element> getContentTypeElement(String contentTypeCodeName, String elementCodeName) {
+        return getContentTypeElement(contentTypeCodeName, elementCodeName, Collections.emptyList());
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public Maybe<Element> getContentTypeElement(
+            String contentTypeCodeName, String elementCodeName, List<NameValuePair> params) {
+        final String apiCall = String.format("%s/%s/%s/%s", TYPES, contentTypeCodeName, ELEMENTS, elementCodeName);
+        return executeRequest(apiCall, params, Element.class);
+    }
+
+    @SuppressWarnings("unused")
+    public Maybe<TaxonomyGroupListingResponse> getTaxonomyGroups() {
+        return getTaxonomyGroups(Collections.emptyList());
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public Maybe<TaxonomyGroupListingResponse> getTaxonomyGroups(List<NameValuePair> params) {
+        return executeRequest(TAXONOMIES, params, TaxonomyGroupListingResponse.class);
+    }
+
+    @SuppressWarnings("unused")
+    public Maybe<TaxonomyGroup> getTaxonomyGroup(String taxonomyGroupCodename) {
+        return getTaxonomyGroup(taxonomyGroupCodename, Collections.emptyList());
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public Maybe<TaxonomyGroup> getTaxonomyGroup(String taxonomyGroupCodename, List<NameValuePair> params) {
+        final String apiCall = String.format(URL_CONCAT, TAXONOMIES, taxonomyGroupCodename);
+        return executeRequest(apiCall, params, TaxonomyGroup.class);
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public ContentLinkUrlResolver getContentLinkUrlResolver() {
+        return contentLinkUrlResolver;
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public void setContentLinkUrlResolver(ContentLinkUrlResolver contentLinkUrlResolver) {
+        this.contentLinkUrlResolver = contentLinkUrlResolver;
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public BrokenLinkUrlResolver getBrokenLinkUrlResolver() {
+        return brokenLinkUrlResolver;
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public void setBrokenLinkUrlResolver(BrokenLinkUrlResolver brokenLinkUrlResolver) {
+        this.brokenLinkUrlResolver = brokenLinkUrlResolver;
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public RichTextElementResolver getRichTextElementResolver() {
+        return richTextElementResolver;
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public void setRichTextElementResolver(RichTextElementResolver richTextElementResolver) {
+        this.richTextElementResolver = richTextElementResolver;
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public void addRichTextElementResolver(RichTextElementResolver richTextElementResolver) {
+        if (this.richTextElementResolver instanceof DelegatingRichTextElementResolver) {
+            ((DelegatingRichTextElementResolver) this.richTextElementResolver).addResolver(richTextElementResolver);
+        } else if (this.richTextElementResolver == null) {
+            setRichTextElementResolver(richTextElementResolver);
+        } else {
+            DelegatingRichTextElementResolver delegatingResolver = new DelegatingRichTextElementResolver();
+            delegatingResolver.addResolver(this.richTextElementResolver);
+            delegatingResolver.addResolver(richTextElementResolver);
+            setRichTextElementResolver(delegatingResolver);
+        }
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public void registerType(String contentType, Class<?> clazz) {
+        stronglyTypedContentItemConverter.registerType(contentType, clazz);
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public void registerType(Class<?> clazz) {
+        stronglyTypedContentItemConverter.registerType(clazz);
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public void registerInlineContentItemsResolver(InlineContentItemsResolver resolver) {
+        stronglyTypedContentItemConverter.registerInlineContentItemsResolver(resolver);
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public void scanClasspathForMappings(String basePackage) {
+        stronglyTypedContentItemConverter.scanClasspathForMappings(basePackage);
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public void setCacheManager(CacheManager cacheManager) {
+        this.cacheManager = cacheManager;
+    }
+
+    private <T> Maybe<T> executeRequest(final String apiCall, final List<NameValuePair> queryParams, Class<T> tClass) {
+        return executeRequest(createUrl(apiCall, queryParams), tClass);
+    }
+
+    private <T> Maybe<T> executeRequest(final String url, Class<T> tClass) {
+        return rxHttpClient.prepare(buildNewRequest(url))
+                .map(this::logResponseInfo)
+                .map(this::handleErrorIfNecessary)
+                .map(Response::getResponseBody)
+                .map(this::bodyToJson)
+                .map(jsonNode -> objectMapper.treeToValue(jsonNode, tClass))
+                .retryWhen(this::configureErrorAndRetryFlow);
+    }
+
+    private Request buildNewRequest(String url) {
+        final Request request = get(url).build();
+
+        request.getHeaders()
+                .add("Accept", "application/json")
+                .add("X-KC-SDKID", sdkId);
+
+        if (deliveryOptions.getProductionApiKey() != null) {
+            request.getHeaders()
+                    .add("Authorization", String.format("Bearer %s", deliveryOptions.getProductionApiKey()));
+        } else if (deliveryOptions.isUsePreviewApi()) {
+            request.getHeaders()
+                    .add("Authorization", String.format("Bearer %s", deliveryOptions.getPreviewApiKey()));
+        }
+        if (deliveryOptions.isWaitForLoadingNewContent()) {
+            request.getHeaders()
+                    .add("X-KC-Wait-For-Loading-New-Content", "true");
+        }
+        return request;
+    }
+
+    private String createUrl(final String apiCall, final List<NameValuePair> queryParams) {
+
+        final String queryStr = Optional.ofNullable(queryParams)
+                .filter(params -> !params.isEmpty())
+                .map(params -> params.stream()
+                        .map(pair -> String.format("%s=%s", pair.getName(), pair.getValue()))
+                        .collect(Collectors.joining("&")))
+                .map("?"::concat)
+                .orElse("");
+
+        final String endpoint = deliveryOptions.isUsePreviewApi() ?
+                deliveryOptions.getPreviewEndpoint() : deliveryOptions.getProductionEndpoint();
+
+        return String.format("%s/%s/%s%s", endpoint, deliveryOptions.getProjectId(), apiCall, queryStr);
+    }
+
+    private Response logResponseInfo(Response response) {
+        log.info("{} - {}", response.getStatusText(), response.getUri());
+        log.debug("{} - {}:\n{}", response.getStatusCode(), response.getUri(), response.getResponseBody());
+        return response;
+    }
+
+    private Response handleErrorIfNecessary(Response response) {
+        final int status = response.getStatusCode();
+        if (status >= 500) {
+            log.error("Kentico API server error, status: {} {}", status, response.getStatusText());
+            String message =
+                    String.format(
+                            "Unknown error with Kentico API.  Kentico is likely suffering site issues.  Status: %s %s",
+                            status, response.getStatusText());
+            throw new KenticoIOException(message);
+        } else if (status >= 400) {
+            log.error("Kentico API server error, status: {}", status);
+            try {
+                KenticoError kenticoError = objectMapper.readValue(response.getResponseBodyAsBytes(), KenticoError.class);
+                throw new KenticoErrorException(kenticoError);
+            } catch (IOException e) {
+                log.error("IOException connecting to Kentico: {}", e.toString());
+                throw new KenticoIOException(e);
+            }
+        }
+
+        return response;
+    }
+
+    private JsonNode bodyToJson(final String body) throws IOException {
+        return objectMapper.readValue(body, JsonNode.class);
+    }
+
+    private Publisher<?> configureErrorAndRetryFlow(Flowable<Throwable> errors) {
+        final AtomicInteger counter = new AtomicInteger(0);
+        return errors
+                .flatMap(throwable -> {
+                    // Don't attempt a retry for Kentico specific errors
+                    if (throwable instanceof KenticoErrorException || throwable instanceof KenticoIOException) {
+                        return Flowable.error(throwable);
+                    }
+                    // Do attempt a retry for any other error while we haven't reached the max attempts yet
+                    else if (counter.incrementAndGet() <= deliveryOptions.getRetryAttempts()) {
+                        return Flowable.just(throwable);
+                    }
+                    // After the max attempts wrap IOExceptions in a KenticoIOException and propagate it
+                    else if (throwable instanceof IOException) {
+                        return Flowable.error(new KenticoIOException((IOException) throwable));
+                    }
+                    // Propagate any other exception as is
+                    else {
+                        return Flowable.error(throwable);
+                    }
+                })
+                .flatMap(e -> {
+                    //Perform a binary exponential backoff
+                    int wait = (int) (100 * Math.pow(2, counter.get()));
+                    log.info("Reattempting request after {}ms (re-attempt {} out of max {})",
+                            wait, counter.get(), deliveryOptions.getRetryAttempts());
+                    return Flowable.timer(wait, TimeUnit.MILLISECONDS);
+                });
+    }
+
+    private List<NameValuePair> addTypeParameterIfNecessary(Class tClass, List<NameValuePair> params) {
+        Optional<NameValuePair> any = params.stream()
+                .filter(nameValuePair -> nameValuePair.getName().equals("system.type"))
+                .findAny();
+        if (!any.isPresent()) {
+            String contentType = stronglyTypedContentItemConverter.getContentType(tClass);
+            if (contentType != null) {
+                List<NameValuePair> updatedParams = new ArrayList<>(params);
+                updatedParams.add(new NameValuePair("system.type", contentType));
+                return updatedParams;
+            }
+        }
+        return params;
+    }
+
+    private void reconfigureDeserializer() {
+        objectMapper = new ObjectMapper();
+
+        SimpleModule module = new SimpleModule();
+        objectMapper.registerModule(new JSR310Module());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        objectMapper.registerModule(module);
+    }
+
+    private RichTextElementConverter createRichTextElementConverter() {
+        return new RichTextElementConverter(
+                getContentLinkUrlResolver(),
+                getBrokenLinkUrlResolver(),
+                getRichTextElementResolver(),
+                templateEngineConfig,
+                stronglyTypedContentItemConverter);
+    }
+
+    DeliveryOptions getDeliveryOptions() {
+        return deliveryOptions;
+    }
+
+    @Override
+    public void close() {
+        if (asyncHttpClient != null) {
+            try {
+                asyncHttpClient.close();
+            } catch (IOException e) {
+                log.warn("Unexpected error while closing the http client", e);
+            }
+        }
+    }
+}

--- a/delivery/src/main/java/com/kenticocloud/delivery/CacheManager.java
+++ b/delivery/src/main/java/com/kenticocloud/delivery/CacheManager.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2017
+ * Copyright (c) 2018
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,15 +26,13 @@ package com.kenticocloud.delivery;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-import java.io.IOException;
+import java.util.List;
 
 /**
  * Interface to provide caching to the {@link DeliveryClient}.
  * <p>
  * An implementation of this can be provided via {@link DeliveryClient#setCacheManager(CacheManager)} and it is invoked
- * before every API request.  It is expected to return a {@link JsonNode} representation of the API response.  In the
- * case of a cache miss, the {@link HttpRequestExecutor} provides an {@code .execute()} callback which returns JsonNode
- * from the KenticoCloud endpoint.  This JsonNode can then be stored by the CacheManager, and returned per the contract.
+ * before every API request.  It is expected to return a {@link JsonNode} representation of the API response.
  * <p>
  * It is up to the CacheManager to determine how to key it's cache, and how much it will introspect the JsonNode,
  * however due to varying operations that can be done with the {@link DeliveryParameterBuilder}, it is highly
@@ -43,50 +41,28 @@ import java.io.IOException;
  * A CacheManager also can leverage notifications from KenticoCloud's webhooks that can be sent when the project's
  * content is changed.
  * <p>
- * This is a {@link FunctionalInterface} to simplify implementation.
- * <p>
- * A simple implementation of this would be as follows (although this example isn't thread safe, do not use):
- * <pre>{@code
- * Map<String, JsonNode> memoryCache = new HashMap<>();
- * deliveryClient.setCacheManager((requestUri, executor) -> {
- *         if (memoryMap.containsKey(requestUri)){
- *             return memoryMap.get(requestUri);
- *         } else {
- *             JsonNode jsonNode = executor.execute();
- *             memoryMap.put(requestUri, jsonNode);
- *             return jsonNode;
- *         }
- *     }
- * );
- * ...
- * protected void purgeCache() {
- *     memoryCache = new HashMap<>();
- * }
- * }</pre>
- * <p>
- * By default, if no CacheManager is provided, the DeliveryClient will use it's default, which just passes through:
- * <pre>{@code
- * private CacheManager cacheManager = (requestUri, executor) -> executor.execute();
- * }</pre>
+ * By default, if no CacheManager is provided, the DeliveryClient will use it's default, which just passes through.
  *
  * @see DeliveryClient#setCacheManager(CacheManager)
- * @see HttpRequestExecutor
  * @see <a href="https://developer.kenticocloud.com/v1/reference#webhooks-and-notifications">
  *      KenticoCloud API reference - Webhooks and notifications</a>
  */
-@FunctionalInterface
 public interface CacheManager {
 
     /**
-     * Invocation of this is a request for the {@link JsonNode} representation of the KenticoCloud response the the API
-     * requestUri built by the SDK.  If this implementation cannot respond, it is expected to acquire the JsonNode from
-     * the {@link HttpRequestExecutor} and return it's response.
+     * Retrieve an earlier cached response from the KenticoCloudDelivery API.
      *
-     * @param requestUri    The requestUri of the KenticoCloud Delivery API request.
-     * @param executor      A callback to execute the API request against the KenticoCloud endpoint.
-     * @return              JsonNode response to the API request.
-     * @throws              IOException This can be thrown by the HttpRequestExecutor indicating a problem with the
-     *                      service, or worse case scenario by the CacheManager itself.
+     * @param url The url that would be used to retrieve the response from KenticoCloud Delivery API.
+     * @return JsonNode response or null if no value is available in the cache for the given url.
      */
-    JsonNode resolveRequest(String requestUri, HttpRequestExecutor executor) throws IOException;
+    JsonNode get(final String url);
+
+    /**
+     * Cache a response from the KenticoCloudDelivery API.
+     *
+     * @param url the URL that was used to retrieve the response from the KenticoCloudDelivery API.
+     * @param jsonNode the JsonNode created from the response from the KenticoCloud Delivery API.
+     * @param containedContentItems (null allowed) can be used to inspect the original contents of the JsonNode and allow for precise cache invalidation (if implemented).
+     */
+    void put(final String url, JsonNode jsonNode, List<ContentItem> containedContentItems);
 }

--- a/delivery/src/main/java/com/kenticocloud/delivery/ContentItemResponse.java
+++ b/delivery/src/main/java/com/kenticocloud/delivery/ContentItemResponse.java
@@ -115,7 +115,7 @@ public class ContentItemResponse implements ModularContentProvider {
         modularContent.values().forEach(contentItem -> contentItem.setModularContentProvider(this));
     }
 
-    void setStronglyTypedContentItemConverter(StronglyTypedContentItemConverter stronglyTypedContentItemConverter) {
+    ContentItemResponse setStronglyTypedContentItemConverter(StronglyTypedContentItemConverter stronglyTypedContentItemConverter) {
         this.stronglyTypedContentItemConverter = stronglyTypedContentItemConverter;
         item.setStronglyTypedContentItemConverter(stronglyTypedContentItemConverter);
         if (modularContent != null) {
@@ -123,5 +123,6 @@ public class ContentItemResponse implements ModularContentProvider {
                 modularContentItem.setStronglyTypedContentItemConverter(stronglyTypedContentItemConverter);
             }
         }
+        return this;
     }
 }

--- a/delivery/src/main/java/com/kenticocloud/delivery/ContentItemsListingResponse.java
+++ b/delivery/src/main/java/com/kenticocloud/delivery/ContentItemsListingResponse.java
@@ -130,7 +130,7 @@ public class ContentItemsListingResponse implements ModularContentProvider {
         this.pagination = pagination;
     }
 
-    void setStronglyTypedContentItemConverter(StronglyTypedContentItemConverter stronglyTypedContentItemConverter) {
+    ContentItemsListingResponse setStronglyTypedContentItemConverter(StronglyTypedContentItemConverter stronglyTypedContentItemConverter) {
         this.stronglyTypedContentItemConverter = stronglyTypedContentItemConverter;
         for (ContentItem item : getItems()) {
             item.setStronglyTypedContentItemConverter(stronglyTypedContentItemConverter);
@@ -140,5 +140,6 @@ public class ContentItemsListingResponse implements ModularContentProvider {
                 modularContentItem.setStronglyTypedContentItemConverter(stronglyTypedContentItemConverter);
             }
         }
+        return this;
     }
 }

--- a/delivery/src/main/java/com/kenticocloud/delivery/DeliveryOptions.java
+++ b/delivery/src/main/java/com/kenticocloud/delivery/DeliveryOptions.java
@@ -49,32 +49,32 @@ public class DeliveryOptions {
      * The Production endpoint address.  Mainly useful to change for mocks in unit tests, or if you are establishing a
      * proxy.
      * <p>
-     * This defaults to "https://deliver.kenticocloud.com/%s", and should be set to a printf-style string.
+     * This defaults to "https://deliver.kenticocloud.com"
      *
      * @param productionEndpoint    New value for the productionEndpoint in this DeliveryOptions instance.
-     * @return                      The value of the printf-style string used as the production endpoint to
+     * @return                      The value of the pstring used as the production endpoint to
      *                              KenticoCloud.
      * @see                     <a href="https://developer.kenticocloud.com/v1/reference#section-production-vs-preview">
      *                          KenticoCloud API reference - Production vs. preview</a>
      * @see                         java.util.Formatter
      */
     @Builder.Default
-    String productionEndpoint = "https://deliver.kenticocloud.com/%s";
+    String productionEndpoint = "https://deliver.kenticocloud.com";
 
     /**
      * The Preview endpoint address.  Mainly useful to change for mocks in unit tests, or if you are establishing a
      * proxy.
      * <p>
-     * This defaults to "https://preview-deliver.kenticocloud.com/%s", and should be set to a printf-style string.
+     * This defaults to "https://preview-deliver.kenticocloud.com"
      *
      * @param previewEndpoint   New value for the productionEndpoint in this DeliveryOptions instance.
-     * @return                  The value of the printf-style string used as the preview endpoint to KenticoCloud.
+     * @return                  The value of the string used as the preview endpoint to KenticoCloud.
      * @see                     <a href="https://developer.kenticocloud.com/v1/reference#section-production-vs-preview">
      *                          KenticoCloud API reference - Production vs. preview</a>
      * @see                     java.util.Formatter
      */
     @Builder.Default
-    String previewEndpoint = "https://preview-deliver.kenticocloud.com/%s";
+    String previewEndpoint = "https://preview-deliver.kenticocloud.com";
 
     /**
      * The Project ID associated with your Kentico Cloud account.  Must be in the format of an {@link java.util.UUID}.

--- a/delivery/src/main/java/com/kenticocloud/delivery/DeliveryParameterBuilder.java
+++ b/delivery/src/main/java/com/kenticocloud/delivery/DeliveryParameterBuilder.java
@@ -24,9 +24,6 @@
 
 package com.kenticocloud.delivery;
 
-import org.apache.http.NameValuePair;
-import org.apache.http.message.BasicNameValuePair;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -226,7 +223,7 @@ public class DeliveryParameterBuilder {
      */
     public DeliveryParameterBuilder filterEquals(String attribute, String value) {
         if (attribute != null) {
-            nameValuePairs.add(new BasicNameValuePair(attribute, value));
+            nameValuePairs.add(new NameValuePair(attribute, value));
         }
         return this;
     }
@@ -244,7 +241,7 @@ public class DeliveryParameterBuilder {
      */
     public DeliveryParameterBuilder filterLessThan(String attribute, String value) {
         if (attribute != null) {
-            nameValuePairs.add(new BasicNameValuePair(String.format("%s%s", attribute, LESS_THAN), value));
+            nameValuePairs.add(new NameValuePair(String.format("%s%s", attribute, LESS_THAN), value));
         }
         return this;
     }
@@ -262,7 +259,7 @@ public class DeliveryParameterBuilder {
      */
     public DeliveryParameterBuilder filterLessThanEquals(String attribute, String value) {
         if (attribute != null) {
-            nameValuePairs.add(new BasicNameValuePair(String.format("%s%s", attribute, LESS_THAN_OR_EQUALS), value));
+            nameValuePairs.add(new NameValuePair(String.format("%s%s", attribute, LESS_THAN_OR_EQUALS), value));
         }
         return this;
     }
@@ -280,7 +277,7 @@ public class DeliveryParameterBuilder {
      */
     public DeliveryParameterBuilder filterGreaterThan(String attribute, String value) {
         if (attribute != null) {
-            nameValuePairs.add(new BasicNameValuePair(String.format("%s%s", attribute, GREATER_THAN), value));
+            nameValuePairs.add(new NameValuePair(String.format("%s%s", attribute, GREATER_THAN), value));
         }
         return this;
     }
@@ -298,7 +295,7 @@ public class DeliveryParameterBuilder {
      */
     public DeliveryParameterBuilder filterGreaterThanEquals(String attribute, String value) {
         if (attribute != null) {
-            nameValuePairs.add(new BasicNameValuePair(String.format("%s%s", attribute, GREATER_THAN_OR_EQUALS), value));
+            nameValuePairs.add(new NameValuePair(String.format("%s%s", attribute, GREATER_THAN_OR_EQUALS), value));
         }
         return this;
     }
@@ -317,7 +314,7 @@ public class DeliveryParameterBuilder {
      */
     public DeliveryParameterBuilder filterRange(String attribute, String lower, String upper) {
         if (attribute != null) {
-            nameValuePairs.add(new BasicNameValuePair(
+            nameValuePairs.add(new NameValuePair(
                     String.format("%s%s", attribute, RANGE),
                     String.join(",", lower, upper)));
         }
@@ -335,7 +332,7 @@ public class DeliveryParameterBuilder {
      */
     public DeliveryParameterBuilder filterIn(String attribute, String... values) {
         if (attribute != null) {
-            nameValuePairs.add(new BasicNameValuePair(String.format("%s%s", attribute, IN), String.join(",", values)));
+            nameValuePairs.add(new NameValuePair(String.format("%s%s", attribute, IN), String.join(",", values)));
         }
         return this;
     }
@@ -366,7 +363,7 @@ public class DeliveryParameterBuilder {
      */
     public DeliveryParameterBuilder filterContains(String attribute, String value) {
         if (attribute != null) {
-            nameValuePairs.add(new BasicNameValuePair(String.format("%s%s", attribute, CONTAINS), value));
+            nameValuePairs.add(new NameValuePair(String.format("%s%s", attribute, CONTAINS), value));
         }
         return this;
     }
@@ -384,7 +381,7 @@ public class DeliveryParameterBuilder {
      */
     public DeliveryParameterBuilder filterAny(String attribute, String... values) {
         if (attribute != null) {
-            nameValuePairs.add(new BasicNameValuePair(String.format("%s%s", attribute, ANY), String.join(",", values)));
+            nameValuePairs.add(new NameValuePair(String.format("%s%s", attribute, ANY), String.join(",", values)));
         }
         return this;
     }
@@ -417,7 +414,7 @@ public class DeliveryParameterBuilder {
      */
     public DeliveryParameterBuilder filterAll(String attribute, String... values) {
         if (attribute != null) {
-            nameValuePairs.add(new BasicNameValuePair(String.format("%s%s", attribute, ALL), String.join(",", values)));
+            nameValuePairs.add(new NameValuePair(String.format("%s%s", attribute, ALL), String.join(",", values)));
         }
         return this;
     }
@@ -448,7 +445,7 @@ public class DeliveryParameterBuilder {
      */
     public DeliveryParameterBuilder orderByAsc(String attribute) {
         if (attribute != null) {
-            nameValuePairs.add(new BasicNameValuePair(ORDER, String.format("%s%s", attribute, ASC)));
+            nameValuePairs.add(new NameValuePair(ORDER, String.format("%s%s", attribute, ASC)));
         }
         return this;
     }
@@ -464,7 +461,7 @@ public class DeliveryParameterBuilder {
      */
     public DeliveryParameterBuilder orderByDesc(String attribute) {
         if (attribute != null) {
-            nameValuePairs.add(new BasicNameValuePair(ORDER, String.format("%s%s", attribute, DESC)));
+            nameValuePairs.add(new NameValuePair(ORDER, String.format("%s%s", attribute, DESC)));
         }
         return this;
     }
@@ -484,11 +481,11 @@ public class DeliveryParameterBuilder {
      */
     public DeliveryParameterBuilder page(Integer skip, Integer limit) {
         if (skip != null) {
-            nameValuePairs.add(new BasicNameValuePair(SKIP, skip.toString()));
+            nameValuePairs.add(new NameValuePair(SKIP, skip.toString()));
         }
 
         if (limit != null) {
-            nameValuePairs.add(new BasicNameValuePair(LIMIT, limit.toString()));
+            nameValuePairs.add(new NameValuePair(LIMIT, limit.toString()));
         }
         return this;
     }
@@ -505,7 +502,7 @@ public class DeliveryParameterBuilder {
      */
     public DeliveryParameterBuilder projection(String... elements) {
         if (elements != null) {
-            nameValuePairs.add(new BasicNameValuePair(ELEMENTS, String.join(",", elements)));
+            nameValuePairs.add(new NameValuePair(ELEMENTS, String.join(",", elements)));
         }
         return this;
     }
@@ -520,7 +517,7 @@ public class DeliveryParameterBuilder {
      */
     public DeliveryParameterBuilder modularContentDepth(Integer depth) {
         if (depth != null) {
-            nameValuePairs.add(new BasicNameValuePair(DEPTH, depth.toString()));
+            nameValuePairs.add(new NameValuePair(DEPTH, depth.toString()));
         }
         return this;
     }
@@ -532,7 +529,7 @@ public class DeliveryParameterBuilder {
      * @see     <a href="https://developer.kenticocloud.com/v1/reference#modular-content">More on Modular content</a>
      */
     public DeliveryParameterBuilder excludeModularContent() {
-        nameValuePairs.add(new BasicNameValuePair(DEPTH, "0"));
+        nameValuePairs.add(new NameValuePair(DEPTH, "0"));
         return this;
     }
 
@@ -549,7 +546,7 @@ public class DeliveryParameterBuilder {
      */
     public DeliveryParameterBuilder language(String language) {
         if (language != null) {
-            nameValuePairs.add(new BasicNameValuePair(LANGUAGE, language));
+            nameValuePairs.add(new NameValuePair(LANGUAGE, language));
         }
         return this;
     }
@@ -567,7 +564,7 @@ public class DeliveryParameterBuilder {
      */
     public DeliveryParameterBuilder language(Locale language) {
         if (language != null) {
-            nameValuePairs.add(new BasicNameValuePair(LANGUAGE, language.toString().replace('_', '-')));
+            nameValuePairs.add(new NameValuePair(LANGUAGE, language.toString().replace('_', '-')));
         }
         return this;
     }

--- a/delivery/src/main/java/com/kenticocloud/delivery/NameValuePair.java
+++ b/delivery/src/main/java/com/kenticocloud/delivery/NameValuePair.java
@@ -1,0 +1,37 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.kenticocloud.delivery;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.io.Serializable;
+
+@Data
+@AllArgsConstructor
+public class NameValuePair implements Serializable {
+    private String name;
+    private String value;
+}

--- a/delivery/src/main/java/com/kenticocloud/delivery/Page.java
+++ b/delivery/src/main/java/com/kenticocloud/delivery/Page.java
@@ -34,15 +34,13 @@ import java.util.List;
 public class Page<T> {
 
     Pagination pagination;
-    DeliveryClient deliveryClient;
     List<T> contentItems;
     Class<T> tClass;
 
-    public Page(ContentItemsListingResponse response, Class<T> tClass, DeliveryClient deliveryClient) {
+    public Page(ContentItemsListingResponse response, Class<T> tClass) {
         this.pagination = response.getPagination();
         this.contentItems = response.castTo(tClass);
         this.tClass = tClass;
-        this.deliveryClient = deliveryClient;
     }
 
     /**
@@ -106,17 +104,6 @@ public class Page<T> {
      */
     public boolean hasPrevious() {
         return pagination.skip > 0;
-    }
-
-    /**
-     * Returns the next page. Can be {@literal null} in case the current page is already the last one. Clients
-     * should check {@link #hasNext()} before calling this method to make sure they receive a non-{@literal null} value.
-     *
-     * @return                      The next page.
-     * @throws KenticoIOException   Thrown if there is an issue communicating with the Kentico Cloud API
-     */
-    public Page<T> nextPage() {
-        return deliveryClient.getNextPage(this);
     }
 
     /**

--- a/delivery/src/main/java/com/kenticocloud/delivery/SimpleInMemoryCacheManager.java
+++ b/delivery/src/main/java/com/kenticocloud/delivery/SimpleInMemoryCacheManager.java
@@ -1,0 +1,133 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.kenticocloud.delivery;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+/**
+ * Uses the JVM memory to cache results.
+ * It also allows cache to be invalidated based on both the codename and language of content items.
+ * This makes it easy to invalidate the cache for incoming webhooks.
+ * <p>
+ * This implementation mainly serves as an example.
+ * Do not use this cache manager when your application is deployed as multiple replicas!
+ * In that case a centralized cache (e.g. Redis) is advisable.
+ */
+public class SimpleInMemoryCacheManager implements CacheManager {
+
+    final protected Map<String, JsonNode> cache = Collections.synchronizedMap(new HashMap<>());
+
+    final protected Map<String, Set<String>> tagsForUrls = Collections.synchronizedMap(new HashMap<>());
+
+    final protected AtomicInteger queries = new AtomicInteger(0);
+    final protected AtomicInteger hits = new AtomicInteger(0);
+    final protected AtomicInteger puts = new AtomicInteger(0);
+
+    @Override
+    public JsonNode get(final String url) {
+        queries.incrementAndGet();
+
+        JsonNode jsonNode = cache.computeIfPresent(url, (key, val) -> {
+            hits.incrementAndGet();
+            return val;
+        });
+
+        return jsonNode;
+    }
+
+    @Override
+    public void put(final String url, final JsonNode jsonNode, final List<ContentItem> containedContentItems) {
+        puts.incrementAndGet();
+        cache.put(url, jsonNode);
+
+        // Store tags that point to the given url.
+        // Tags are created for every code_name+language combination that can be determined from the given containedContentItems
+        Optional.ofNullable(containedContentItems)
+                .map(this::createCacheTags)
+                .orElse(Collections.emptySet())
+                .forEach(cacheTag -> getUrlsForTag(cacheTag).add(url));
+    }
+
+    public void invalidate(final String url) {
+        cache.remove(url);
+    }
+
+    public void invalidate(final CacheTag cacheTag) {
+        // Possible race condition
+        Set<String> urls = getUrlsForTag(cacheTag);
+        urls.forEach(url -> {
+            invalidate(url);
+            urls.remove(url);
+        });
+    }
+
+    private Set<String> getUrlsForTag(final CacheTag cacheTag) {
+        tagsForUrls.putIfAbsent(cacheTag.toString(), Collections.synchronizedSet(new HashSet<>()));
+        return tagsForUrls.get(cacheTag.toString());
+    }
+
+    private Set<CacheTag> createCacheTags(final List<ContentItem> containedContentItems) {
+        return containedContentItems.stream()
+                .map(this::createCacheTags)
+                .flatMap(Set::stream)
+                .collect(Collectors.toSet());
+    }
+
+    private Set<CacheTag> createCacheTags(final ContentItem contentItem) {
+        Set<CacheTag> tags = new HashSet<>();
+        tags.add(new CacheTag(contentItem));
+
+        tags.addAll(
+                contentItem.getModularContentProvider().getModularContent().values().stream()
+                        .map(CacheTag::new)
+                        .collect(Collectors.toSet())
+        );
+
+        return tags;
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class CacheTag {
+        String codeName;
+        String language;
+
+        public CacheTag(ContentItem contentItem) {
+            codeName = contentItem.getSystem().getCodename();
+            language = contentItem.getSystem().getLanguage();
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%s#%s", codeName, language);
+        }
+    }
+}

--- a/delivery/src/test/java/com/kenticocloud/delivery/DeliveryClientTest.java
+++ b/delivery/src/test/java/com/kenticocloud/delivery/DeliveryClientTest.java
@@ -41,12 +41,13 @@ import org.junit.Test;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.lang.reflect.Field;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class DeliveryClientTest extends LocalServerTestBase {
 
@@ -70,25 +71,24 @@ public class DeliveryClientTest extends LocalServerTestBase {
         HttpHost httpHost = this.start();
         DeliveryClient client = new DeliveryClient(projectId, previewApiKey);
 
-        //modify default baseUrl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setPreviewEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setPreviewEndpoint(testServerUri);
 
         ContentItemResponse item = client.getItem("on_roasts");
         Assert.assertNotNull(item);
+
+        client.close();
     }
 
     @Test
     public void testRetry() throws Exception {
         String projectId = "02a70003-e864-464e-b62c-e0ede97deb8c";
-        final boolean[] sentError = {false};
+        final AtomicBoolean sentError = new AtomicBoolean(false);
 
         this.serverBootstrap.registerHandler(
                 String.format("/%s/%s", projectId, "items/on_roasts"),
                 (request, response, context) -> {
-                    if (sentError[0]) {
+                    if (sentError.get()) {
                         response.setEntity(
                                 new InputStreamEntity(
                                         this.getClass().getResourceAsStream("SampleContentItem.json")
@@ -96,11 +96,11 @@ public class DeliveryClientTest extends LocalServerTestBase {
                         );
                     } else {
                         response.setEntity(new StringEntity("Response Error!"));
-                        sentError[0] = true;
+                        sentError.set(true);
                     }
                 });
         HttpHost httpHost = this.start();
-        String testServerUri = httpHost.toURI() + "/%s";
+        String testServerUri = httpHost.toURI();
         DeliveryOptions deliveryOptions = new DeliveryOptions();
         deliveryOptions.setProjectId(projectId);
         deliveryOptions.setProductionEndpoint(testServerUri);
@@ -110,22 +110,24 @@ public class DeliveryClientTest extends LocalServerTestBase {
 
         ContentItemResponse item = client.getItem("on_roasts");
         Assert.assertNotNull(item);
-        Assert.assertTrue(sentError[0]);
+        Assert.assertTrue(sentError.get());
+
+        client.close();
     }
 
     @Test
     public void testRetryStops() throws Exception {
         String projectId = "02a70003-e864-464e-b62c-e0ede97deb8c";
-        final int[] sentErrorCount = {0};
+        final AtomicInteger sentErrorCount = new AtomicInteger(0);
 
         this.serverBootstrap.registerHandler(
                 String.format("/%s/%s", projectId, "items/on_roasts"),
                 (request, response, context) -> {
                     response.setEntity(new StringEntity("Response Error!"));
-                    sentErrorCount[0] = sentErrorCount[0] + 1;
+                    sentErrorCount.getAndIncrement();
                 });
         HttpHost httpHost = this.start();
-        String testServerUri = httpHost.toURI() + "/%s";
+        String testServerUri = httpHost.toURI();
         DeliveryOptions deliveryOptions = DeliveryOptions.builder()
                 .projectId(projectId)
                 .productionEndpoint(testServerUri)
@@ -135,16 +137,14 @@ public class DeliveryClientTest extends LocalServerTestBase {
         deliveryOptions.setProductionEndpoint(testServerUri);
         deliveryOptions.setRetryAttempts(1);
 
-        DeliveryClient client = new DeliveryClient(deliveryOptions);
-
-        try {
+        try (DeliveryClient client = new DeliveryClient(deliveryOptions)) {
             client.getItem("on_roasts");
             Assert.fail("Expected a failure exception");
         } catch (Exception e) {
             Assert.assertTrue(e instanceof KenticoIOException);
             Assert.assertTrue(e.getCause() instanceof JsonParseException);
         }
-        Assert.assertEquals(2, sentErrorCount[0]);
+        Assert.assertEquals(2, sentErrorCount.get());
     }
 
     @Test
@@ -164,15 +164,13 @@ public class DeliveryClientTest extends LocalServerTestBase {
                     sentErrorCount[0] = sentErrorCount[0] + 1;
                 });
         HttpHost httpHost = this.start();
-        String testServerUri = httpHost.toURI() + "/%s";
+        String testServerUri = httpHost.toURI();
         DeliveryOptions deliveryOptions = new DeliveryOptions();
         deliveryOptions.setProjectId(projectId);
         deliveryOptions.setProductionEndpoint(testServerUri);
         deliveryOptions.setRetryAttempts(1);
 
-        DeliveryClient client = new DeliveryClient(deliveryOptions);
-
-        try {
+        try (DeliveryClient client = new DeliveryClient(deliveryOptions)) {
             client.getItem("error");
             Assert.fail("Expected KenticoErrorException");
         } catch (KenticoErrorException e) {
@@ -203,7 +201,7 @@ public class DeliveryClientTest extends LocalServerTestBase {
                     );
                 });
         HttpHost httpHost = this.start();
-        String testServerUri = httpHost.toURI() + "/%s";
+        String testServerUri = httpHost.toURI();
         DeliveryOptions deliveryOptions = new DeliveryOptions();
         deliveryOptions.setProjectId(projectId);
         deliveryOptions.setProductionEndpoint(testServerUri);
@@ -213,12 +211,14 @@ public class DeliveryClientTest extends LocalServerTestBase {
         client.setBrokenLinkUrlResolver(() -> "/404");
         client.addRichTextElementResolver(content -> String.format("%s%s", "<p>test</p>", content));
 
-        List<NameValuePair> urlPattern = DeliveryParameterBuilder.params().filterEquals("elements.url_pattern", "/path1/path2/test-article").build();
+        List<com.kenticocloud.delivery.NameValuePair> urlPattern = DeliveryParameterBuilder.params().filterEquals("elements.url_pattern", "/path1/path2/test-article").build();
         ContentItemsListingResponse items = client.getItems(urlPattern);
 
         Assert.assertNotNull(items);
         Assert.assertTrue(((RichTextElement) items.getItems().get(1).getElements().get("description")).getValue().contains("href=\"/on roasts\""));
         Assert.assertTrue(((RichTextElement) items.getItems().get(1).getElements().get("description")).getValue().contains("<p>test</p>"));
+
+        client.close();
     }
 
     @Test
@@ -235,12 +235,14 @@ public class DeliveryClientTest extends LocalServerTestBase {
         HttpHost httpHost = this.start();
 
         DeliveryOptions deliveryOptions = new DeliveryOptions();
-        deliveryOptions.setProductionEndpoint(httpHost.toURI() + "/%s");
+        deliveryOptions.setProductionEndpoint(httpHost.toURI());
         deliveryOptions.setProjectId(projectId);
         DeliveryClient client = new DeliveryClient(deliveryOptions, null);
 
         ContentItemsListingResponse items = client.getItems();
         Assert.assertNotNull(items);
+
+        client.close();
     }
 
     @Test
@@ -294,7 +296,7 @@ public class DeliveryClientTest extends LocalServerTestBase {
                 ));
         HttpHost httpHost = this.start();
         DeliveryOptions deliveryOptions = new DeliveryOptions();
-        deliveryOptions.setProductionEndpoint(httpHost.toURI() + "/%s");
+        deliveryOptions.setProductionEndpoint(httpHost.toURI());
         deliveryOptions.setProjectId(projectId);
         DeliveryClient client = new DeliveryClient(deliveryOptions, null);
 
@@ -308,7 +310,7 @@ public class DeliveryClientTest extends LocalServerTestBase {
         Assert.assertTrue(pageOfItems.hasNext());
         Assert.assertFalse(pageOfItems.hasPrevious());
 
-        Page<ContentItem> nextPage = pageOfItems.nextPage();
+        Page<ContentItem> nextPage = client.getNextPage(pageOfItems);
         Assert.assertEquals(0, nextPage.getSize());
         Assert.assertFalse(nextPage.hasContent());
         Assert.assertFalse(nextPage.isFirst());
@@ -316,23 +318,19 @@ public class DeliveryClientTest extends LocalServerTestBase {
         Assert.assertFalse(nextPage.hasNext());
         Assert.assertTrue(nextPage.hasPrevious());
 
-        Assert.assertNull(nextPage.nextPage());
+        Assert.assertNull(client.getNextPage(nextPage));
+
+        client.close();
     }
 
     @Test
-    @SuppressWarnings("all")
+    @SuppressWarnings("Duplicates")
     public void testStronglyTypedGetItemsAsPage() throws Exception {
         String projectId = "02a70003-e864-464e-b62c-e0ede97deb8c";
 
         this.serverBootstrap.registerHandler(
                 String.format("/%s/%s", projectId, "items"),
                 (request, response, context) -> {
-                    String uri = String.format("http://testserver%s", request.getRequestLine().getUri());
-
-                    List<NameValuePair> nameValuePairs =
-                            URLEncodedUtils.parse(URI.create(uri), Charset.defaultCharset());
-                    Map<String, String> params = convertNameValuePairsToMap(nameValuePairs);
-
                     BufferedReader bufferedReader =
                             new BufferedReader(
                                     new InputStreamReader(
@@ -370,7 +368,7 @@ public class DeliveryClientTest extends LocalServerTestBase {
                 ));
         HttpHost httpHost = this.start();
         DeliveryOptions deliveryOptions = new DeliveryOptions();
-        deliveryOptions.setProductionEndpoint(httpHost.toURI() + "/%s");
+        deliveryOptions.setProductionEndpoint(httpHost.toURI());
         deliveryOptions.setProjectId(projectId);
         DeliveryClient client = new DeliveryClient(deliveryOptions, null);
 
@@ -384,7 +382,7 @@ public class DeliveryClientTest extends LocalServerTestBase {
         Assert.assertTrue(pageOfItems.hasNext());
         Assert.assertFalse(pageOfItems.hasPrevious());
 
-        Page<ArticleItem> nextPage = pageOfItems.nextPage();
+        Page<ArticleItem> nextPage = client.getNextPage(pageOfItems);
         Assert.assertEquals(0, nextPage.getSize());
         Assert.assertFalse(nextPage.hasContent());
         Assert.assertFalse(nextPage.isFirst());
@@ -392,7 +390,11 @@ public class DeliveryClientTest extends LocalServerTestBase {
         Assert.assertFalse(nextPage.hasNext());
         Assert.assertTrue(nextPage.hasPrevious());
 
-        Assert.assertNull(nextPage.nextPage());
+        java.lang.System.out.println("$$$$$$$$$$$$$$$$$$$$$$");
+
+        Assert.assertNull(client.getNextPage(nextPage));
+
+        client.close();
     }
 
     @Test
@@ -416,7 +418,7 @@ public class DeliveryClientTest extends LocalServerTestBase {
                     );
                 });
         HttpHost httpHost = this.start();
-        String testServerUri = httpHost.toURI() + "/%s";
+        String testServerUri = httpHost.toURI();
         DeliveryOptions deliveryOptions = new DeliveryOptions();
         deliveryOptions.setProjectId(projectId);
         deliveryOptions.setProductionEndpoint(testServerUri);
@@ -424,10 +426,12 @@ public class DeliveryClientTest extends LocalServerTestBase {
         DeliveryClient client = new DeliveryClient(deliveryOptions);
         client.setContentLinkUrlResolver(Link::getUrlSlug);
 
-        List<NameValuePair> urlPattern = DeliveryParameterBuilder.params().filterEquals("elements.url_pattern", "/path1/path2/test-article").build();
+        List<com.kenticocloud.delivery.NameValuePair> urlPattern = DeliveryParameterBuilder.params().filterEquals("elements.url_pattern", "/path1/path2/test-article").build();
         ContentItemResponse item = client.getItem("on_roasts", urlPattern);
 
         Assert.assertNotNull(item);
+
+        client.close();
     }
 
     @Test
@@ -444,14 +448,13 @@ public class DeliveryClientTest extends LocalServerTestBase {
         HttpHost httpHost = this.start();
         DeliveryClient client = new DeliveryClient(projectId);
 
-        //modify default baseUrl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         ContentItemResponse item = client.getItem("on_roasts");
         Assert.assertNotNull(item);
+
+        client.close();
     }
 
     @Test
@@ -468,14 +471,13 @@ public class DeliveryClientTest extends LocalServerTestBase {
         HttpHost httpHost = this.start();
         DeliveryClient client = new DeliveryClient(projectId);
 
-        //modify default baseUrl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         TaxonomyGroupListingResponse response = client.getTaxonomyGroups();
         Assert.assertNotNull(response);
+
+        client.close();
     }
 
     @Test
@@ -493,26 +495,25 @@ public class DeliveryClientTest extends LocalServerTestBase {
         HttpHost httpHost = this.start();
         DeliveryClient client = new DeliveryClient(projectId);
 
-        //modify default baseUrl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         TaxonomyGroup taxonomyGroup = client.getTaxonomyGroup("personas");
         Assert.assertNotNull(taxonomyGroup);
+
+        client.close();
     }
 
     @Test
-    public void testCache() throws Exception {
+    public void testCache() {
         String projectId = "02a70003-e864-464e-b62c-e0ede97deb8c";
         DeliveryClient client = new DeliveryClient(projectId);
-        final boolean[] cacheHit = {false};
+        final AtomicBoolean cacheHit = new AtomicBoolean(false);
         client.setCacheManager(new CacheManager() {
             @Override
             public JsonNode resolveRequest(String requestUri, HttpRequestExecutor executor) throws IOException {
                 Assert.assertEquals("https://deliver.kenticocloud.com/02a70003-e864-464e-b62c-e0ede97deb8c/items/on_roasts", requestUri);
-                cacheHit[0] = true;
+                cacheHit.set(true);
                 ObjectMapper objectMapper = new ObjectMapper();
                 objectMapper.registerModule(new JSR310Module());
                 objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
@@ -521,7 +522,9 @@ public class DeliveryClientTest extends LocalServerTestBase {
         });
         ContentItemResponse item = client.getItem("on_roasts");
         Assert.assertNotNull(item);
-        Assert.assertTrue(cacheHit[0]);
+        Assert.assertTrue(cacheHit.get());
+
+        client.close();
     }
 
     @Test
@@ -539,6 +542,8 @@ public class DeliveryClientTest extends LocalServerTestBase {
         Assert.assertTrue(deliveryClient.getRichTextElementResolver() instanceof DelegatingRichTextElementResolver);
         Assert.assertEquals(2, ((DelegatingRichTextElementResolver) deliveryClient.getRichTextElementResolver()).resolvers.size());
         Assert.assertEquals("resolver2", deliveryClient.getRichTextElementResolver().resolve("replaceme"));
+
+        deliveryClient.close();
     }
 
     @Test
@@ -555,11 +560,8 @@ public class DeliveryClientTest extends LocalServerTestBase {
         HttpHost httpHost = this.start();
         DeliveryClient client = new DeliveryClient(projectId);
 
-        //modify default baseUrl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         ArticleItem item = client.getItem("on_roasts", ArticleItem.class);
         Assert.assertNotNull(item);
@@ -583,6 +585,8 @@ public class DeliveryClientTest extends LocalServerTestBase {
         Assert.assertEquals(2, item.getAllModularContent().size());
         Assert.assertNotNull(item.getAllModularContentMap());
         Assert.assertEquals(2, item.getAllModularContentMap().size());
+
+        client.close();
     }
 
     @Test
@@ -609,15 +613,14 @@ public class DeliveryClientTest extends LocalServerTestBase {
         DeliveryClient client = new DeliveryClient(projectId);
         client.registerType("article", ArticleItem.class);
 
-        //modify default baseUrl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         Object itemObj = client.getItem("on_roasts", Object.class);
         Assert.assertNotNull(itemObj);
         Assert.assertTrue(itemObj instanceof ArticleItem);
+
+        client.close();
     }
 
     @Test
@@ -650,14 +653,13 @@ public class DeliveryClientTest extends LocalServerTestBase {
         DeliveryClient client = new DeliveryClient(projectId);
         client.registerType("article", ArticleItem.class);
 
-        //modify default baseUrl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         ArticleItem itemObj = client.getItem("on_roasts", ArticleItem.class);
         Assert.assertNotNull(itemObj);
+
+        client.close();
     }
 
     @Test
@@ -689,11 +691,8 @@ public class DeliveryClientTest extends LocalServerTestBase {
         DeliveryClient client = new DeliveryClient(projectId);
         client.registerType("article", ArticleItem.class);
 
-        //modify default baseUrl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         ArticleItem itemObj = client.getItem(
                 "on_roasts",
@@ -702,6 +701,8 @@ public class DeliveryClientTest extends LocalServerTestBase {
                         .filterEquals("system.type", "customVal")
                         .build());
         Assert.assertNotNull(itemObj);
+
+        client.close();
     }
 
     @Test
@@ -719,15 +720,14 @@ public class DeliveryClientTest extends LocalServerTestBase {
         DeliveryClient client = new DeliveryClient(projectId);
         client.registerType(ArticleItem.class);
 
-        //modify default baseUrl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         Object itemObj = client.getItem("on_roasts", Object.class);
         Assert.assertNotNull(itemObj);
         Assert.assertTrue(itemObj instanceof ArticleItem);
+
+        client.close();
     }
 
     @Test
@@ -745,11 +745,8 @@ public class DeliveryClientTest extends LocalServerTestBase {
         DeliveryClient client = new DeliveryClient(projectId);
         client.registerType(ArticleItem.class);
 
-        //modify default baseUrl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         ContentItemResponse response = client.getItem("on_roasts");
         ContentItem itemObj = response.getItem();
@@ -757,6 +754,8 @@ public class DeliveryClientTest extends LocalServerTestBase {
         Object casted = itemObj.castToDefault();
         Assert.assertNotNull(casted);
         Assert.assertTrue(casted instanceof ArticleItem);
+
+        client.close();
     }
 
     @Test
@@ -774,11 +773,8 @@ public class DeliveryClientTest extends LocalServerTestBase {
         DeliveryClient client = new DeliveryClient(projectId);
         client.registerType(ArticleItem.class);
 
-        //modify default baseUrl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         ContentItemResponse response = client.getItem("on_roasts");
         ContentItem itemObj = response.getItem();
@@ -786,6 +782,8 @@ public class DeliveryClientTest extends LocalServerTestBase {
         Object casted = itemObj.castTo("article");
         Assert.assertNotNull(casted);
         Assert.assertTrue(casted instanceof ArticleItem);
+
+        client.close();
     }
 
     @Test
@@ -804,11 +802,8 @@ public class DeliveryClientTest extends LocalServerTestBase {
         DeliveryClient client = new DeliveryClient(projectId);
         client.registerType(ArticleItem.class);
 
-        //modify default baseUrl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         ArticleItem itemObj = client.getItem("on_roasts", ArticleItem.class);
         Assert.assertNotNull(itemObj);
@@ -821,6 +816,8 @@ public class DeliveryClientTest extends LocalServerTestBase {
         Assert.assertNotNull(itemObj.getRelatedArticlesMap());
         Assert.assertEquals(2, itemObj.getRelatedArticlesMap().size());
         Assert.assertTrue(itemObj.getRelatedArticlesMap().get("coffee_processing_techniques") instanceof ContentItem);
+
+        client.close();
     }
 
     @Test
@@ -838,15 +835,14 @@ public class DeliveryClientTest extends LocalServerTestBase {
         DeliveryClient client = new DeliveryClient(projectId);
         client.scanClasspathForMappings("com.kenticocloud");
 
-        //modify default baseUrl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         Object itemObj = client.getItem("on_roasts", Object.class);
         Assert.assertNotNull(itemObj);
         Assert.assertTrue(itemObj instanceof ArticleItem);
+
+        client.close();
     }
 
     @Test
@@ -874,11 +870,8 @@ public class DeliveryClientTest extends LocalServerTestBase {
         HttpHost httpHost = this.start();
         DeliveryClient client = new DeliveryClient(projectId);
 
-        //modify default baseUrl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
         client.registerType(ArticleItem.class);
         client.registerInlineContentItemsResolver(new InlineContentItemsResolver<ArticleItem>() {
             @Override
@@ -891,6 +884,8 @@ public class DeliveryClientTest extends LocalServerTestBase {
         Assert.assertNotNull(items);
         Assert.assertFalse(items.get(1).getDescription().contains("<object"));
         Assert.assertTrue(items.get(1).getDescription().contains("WE REPLACED SUCCESSFULLY"));
+
+        client.close();
     }
 
     @Test
@@ -911,7 +906,7 @@ public class DeliveryClientTest extends LocalServerTestBase {
                     );
                 });
         HttpHost httpHost = this.start();
-        String testServerUri = httpHost.toURI() + "/%s";
+        String testServerUri = httpHost.toURI();
 
         DeliveryOptions options = new DeliveryOptions();
         options.setProjectId(projectId);
@@ -922,6 +917,8 @@ public class DeliveryClientTest extends LocalServerTestBase {
 
         ContentItemResponse item = client.getItem("on_roasts");
         Assert.assertNotNull(item);
+
+        client.close();
     }
 
     @Test
@@ -944,14 +941,13 @@ public class DeliveryClientTest extends LocalServerTestBase {
         HttpHost httpHost = this.start();
         DeliveryClient client = new DeliveryClient(projectId, previewApiKey);
 
-        //modify default baseUrl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setPreviewEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setPreviewEndpoint(testServerUri);
 
         ContentItemResponse item = client.getItem("on_roasts");
         Assert.assertNotNull(item);
+
+        client.close();
     }
 
     @Test
@@ -971,7 +967,7 @@ public class DeliveryClientTest extends LocalServerTestBase {
                     );
                 });
         HttpHost httpHost = this.start();
-        String testServerUri = httpHost.toURI() + "/%s";
+        String testServerUri = httpHost.toURI();
         DeliveryOptions deliveryOptions = new DeliveryOptions();
         deliveryOptions.setProjectId(projectId);
         deliveryOptions.setProductionEndpoint(testServerUri);
@@ -980,6 +976,8 @@ public class DeliveryClientTest extends LocalServerTestBase {
 
         ContentItemResponse item = client.getItem("on_roasts");
         Assert.assertNotNull(item);
+
+        client.close();
     }
 
     @Test
@@ -1000,11 +998,8 @@ public class DeliveryClientTest extends LocalServerTestBase {
         HttpHost httpHost = this.start();
         DeliveryClient client = new DeliveryClient(projectId);
 
-        //modify default baseUrl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         try {
             ContentItemResponse item = client.getItem("error");
@@ -1013,6 +1008,8 @@ public class DeliveryClientTest extends LocalServerTestBase {
             Assert.assertEquals("The requested content item 'error' was not found.", e.getMessage());
             Assert.assertEquals("The requested content item 'error' was not found.", e.getKenticoError().getMessage());
         }
+
+        client.close();
     }
 
     @Test
@@ -1026,17 +1023,16 @@ public class DeliveryClientTest extends LocalServerTestBase {
         HttpHost httpHost = this.start();
         DeliveryClient client = new DeliveryClient(projectId);
 
-        //modify default baseUrl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         try {
             ContentItemResponse item = client.getItem("error");
             Assert.fail("Expected IOException");
         } catch (KenticoIOException e) {
-            Assert.assertEquals("Unknown error with Kentico API.  Kentico is likely suffering site issues.  Status: HTTP/1.1 500 Internal Server Error", e.getMessage());
+            Assert.assertEquals("Unknown error with Kentico API.  Kentico is likely suffering site issues.  Status: 500 Internal Server Error", e.getMessage());
+        } finally {
+            client.close();
         }
     }
 
@@ -1061,7 +1057,7 @@ public class DeliveryClientTest extends LocalServerTestBase {
                     );
                 });
         HttpHost httpHost = this.start();
-        String testServerUri = httpHost.toURI() + "/%s";
+        String testServerUri = httpHost.toURI();
         DeliveryOptions deliveryOptions = new DeliveryOptions();
         deliveryOptions.setProjectId(projectId);
         deliveryOptions.setProductionEndpoint(testServerUri);
@@ -1069,10 +1065,12 @@ public class DeliveryClientTest extends LocalServerTestBase {
         DeliveryClient client = new DeliveryClient(deliveryOptions);
         client.setContentLinkUrlResolver(Link::getUrlSlug);
 
-        List<NameValuePair> urlPattern = DeliveryParameterBuilder.params().filterEquals("elements.url_pattern", "/path1/path2/test-article").build();
+        List<com.kenticocloud.delivery.NameValuePair> urlPattern = DeliveryParameterBuilder.params().filterEquals("elements.url_pattern", "/path1/path2/test-article").build();
         ContentTypesListingResponse types = client.getTypes(urlPattern);
 
         Assert.assertNotNull(types);
+
+        client.close();
     }
 
     @Test
@@ -1089,14 +1087,13 @@ public class DeliveryClientTest extends LocalServerTestBase {
         HttpHost httpHost = this.start();
         DeliveryClient client = new DeliveryClient(projectId);
 
-        //modify default baseUrl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         ContentTypesListingResponse types = client.getTypes();
         Assert.assertNotNull(types);
+
+        client.close();
     }
 
     @Test
@@ -1114,14 +1111,13 @@ public class DeliveryClientTest extends LocalServerTestBase {
         HttpHost httpHost = this.start();
         DeliveryClient client = new DeliveryClient(projectId);
 
-        //modify default baseUrl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         ContentType type = client.getType("coffee");
         Assert.assertNotNull(type);
+
+        client.close();
     }
 
     @Test
@@ -1145,7 +1141,7 @@ public class DeliveryClientTest extends LocalServerTestBase {
                     );
                 });
         HttpHost httpHost = this.start();
-        String testServerUri = httpHost.toURI() + "/%s";
+        String testServerUri = httpHost.toURI();
         DeliveryOptions deliveryOptions = new DeliveryOptions();
         deliveryOptions.setProjectId(projectId);
         deliveryOptions.setProductionEndpoint(testServerUri);
@@ -1153,12 +1149,14 @@ public class DeliveryClientTest extends LocalServerTestBase {
         DeliveryClient client = new DeliveryClient(deliveryOptions);
         client.setContentLinkUrlResolver(Link::getUrlSlug);
 
-        List<NameValuePair> urlPattern = DeliveryParameterBuilder.params().filterEquals("elements.url_pattern", "/path1/path2/test-article").build();
+        List<com.kenticocloud.delivery.NameValuePair> urlPattern = DeliveryParameterBuilder.params().filterEquals("elements.url_pattern", "/path1/path2/test-article").build();
         Element element = client.getContentTypeElement("coffee", "processing", urlPattern);
 
         Assert.assertNotNull(element);
         Assert.assertEquals("processing", element.getCodeName());
         Assert.assertTrue(element instanceof MultipleChoiceElement);
+
+        client.close();
     }
 
     @Test
@@ -1176,24 +1174,22 @@ public class DeliveryClientTest extends LocalServerTestBase {
         HttpHost httpHost = this.start();
         DeliveryClient client = new DeliveryClient(projectId);
 
-        //modify default baseUrl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         Element element = client.getContentTypeElement("coffee", "processing");
         Assert.assertNotNull(element);
         Assert.assertEquals("processing", element.getCodeName());
         Assert.assertTrue(element instanceof MultipleChoiceElement);
+
+        client.close();
     }
 
     @Test
     @SuppressWarnings("all")
     public void testExceptionWhenProjectIdIsNull() {
         DeliveryOptions deliveryOptions = new DeliveryOptions();
-        try {
-            DeliveryClient client = new DeliveryClient(deliveryOptions);
+        try (DeliveryClient client = new DeliveryClient(deliveryOptions)) {
             Assert.fail("Expected IllegalArgumentException due to null Project Id");
         } catch (IllegalArgumentException e) {
             Assert.assertEquals("Kentico Cloud project identifier is not specified.", e.getMessage());
@@ -1205,8 +1201,7 @@ public class DeliveryClientTest extends LocalServerTestBase {
     public void testExceptionWhenProjectIdIsEmpty() {
         DeliveryOptions deliveryOptions = new DeliveryOptions();
         deliveryOptions.setProjectId("");
-        try {
-            DeliveryClient client = new DeliveryClient(deliveryOptions);
+        try (DeliveryClient client = new DeliveryClient(deliveryOptions)) {
             Assert.fail("Expected IllegalArgumentException due to empty Project Id");
         } catch (IllegalArgumentException e) {
             Assert.assertEquals("Kentico Cloud project identifier is not specified.", e.getMessage());
@@ -1216,9 +1211,8 @@ public class DeliveryClientTest extends LocalServerTestBase {
     @Test
     @SuppressWarnings("all")
     public void testExceptionWhenDeliveryOptionsIsNull() {
-        try {
-            DeliveryOptions deliveryOptions = null;
-            DeliveryClient client = new DeliveryClient(deliveryOptions);
+        DeliveryOptions deliveryOptions = null;
+        try (DeliveryClient client = new DeliveryClient(deliveryOptions)) {
             Assert.fail("Expected IllegalArgumentException due to null Delivery options");
         } catch (IllegalArgumentException e) {
             Assert.assertEquals("The Delivery options object is not specified.", e.getMessage());
@@ -1230,8 +1224,7 @@ public class DeliveryClientTest extends LocalServerTestBase {
     public void testExceptionWhenInvalidProjectIdProvided() {
         DeliveryOptions deliveryOptions = new DeliveryOptions();
         deliveryOptions.setProjectId("Invalid GUID");
-        try {
-            DeliveryClient client = new DeliveryClient(deliveryOptions);
+        try (DeliveryClient client = new DeliveryClient(deliveryOptions)) {
             Assert.fail("Expected IllegalArgumentException due to invalid Project ID");
         } catch (IllegalArgumentException e) {
             Assert.assertEquals("Provided string is not a valid project identifier (Invalid GUID).  Have you accidentally passed the Preview API key instead of the project identifier?", e.getMessage());
@@ -1244,8 +1237,7 @@ public class DeliveryClientTest extends LocalServerTestBase {
         DeliveryOptions deliveryOptions = new DeliveryOptions();
         deliveryOptions.setProjectId("02a70003-e864-464e-b62c-e0ede97deb8c");
         deliveryOptions.setUsePreviewApi(true);
-        try {
-            DeliveryClient client = new DeliveryClient(deliveryOptions);
+        try (DeliveryClient client = new DeliveryClient(deliveryOptions)) {
             Assert.fail("Expected IllegalArgumentException due to null Preview API Key");
         } catch (IllegalArgumentException e) {
             Assert.assertEquals("The Preview API key is not specified.", e.getMessage());
@@ -1259,8 +1251,7 @@ public class DeliveryClientTest extends LocalServerTestBase {
         deliveryOptions.setProjectId("02a70003-e864-464e-b62c-e0ede97deb8c");
         deliveryOptions.setUsePreviewApi(true);
         deliveryOptions.setPreviewApiKey("");
-        try {
-            DeliveryClient client = new DeliveryClient(deliveryOptions);
+        try (DeliveryClient client = new DeliveryClient(deliveryOptions)) {
             Assert.fail("Expected IllegalArgumentException due to empty Preview API Key");
         } catch (IllegalArgumentException e) {
             Assert.assertEquals("The Preview API key is not specified.", e.getMessage());
@@ -1273,8 +1264,7 @@ public class DeliveryClientTest extends LocalServerTestBase {
         DeliveryOptions deliveryOptions =
                 new DeliveryOptions("02a70003-e864-464e-b62c-e0ede97deb8c", "preview_api_key");
         deliveryOptions.setProductionApiKey("production_api_key");
-        try {
-            DeliveryClient client = new DeliveryClient(deliveryOptions);
+        try (DeliveryClient client = new DeliveryClient(deliveryOptions)) {
             Assert.fail("Expected IllegalArgumentException due to providing both a preview and production API key");
         } catch (IllegalArgumentException e) {
             Assert.assertEquals("Cannot provide both a preview API key and a production API key.", e.getMessage());
@@ -1287,8 +1277,7 @@ public class DeliveryClientTest extends LocalServerTestBase {
         DeliveryOptions deliveryOptions = new DeliveryOptions();
         deliveryOptions.setProjectId("02a70003-e864-464e-b62c-e0ede97deb8c");
         deliveryOptions.setRetryAttempts(-1);
-        try {
-            DeliveryClient client = new DeliveryClient(deliveryOptions);
+        try (DeliveryClient client = new DeliveryClient(deliveryOptions)) {
             Assert.fail("Expected IllegalArgumentException due to negative number provided for retry count");
         } catch (IllegalArgumentException e) {
             Assert.assertEquals("Cannot retry connections less than 0 times.", e.getMessage());

--- a/delivery/src/test/java/com/kenticocloud/delivery/DeliveryParameterBuilderTest.java
+++ b/delivery/src/test/java/com/kenticocloud/delivery/DeliveryParameterBuilderTest.java
@@ -24,7 +24,7 @@
 
 package com.kenticocloud.delivery;
 
-import org.apache.http.NameValuePair;
+import com.kenticocloud.delivery.NameValuePair;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/delivery/src/test/java/com/kenticocloud/delivery/DocsExamplesTest.java
+++ b/delivery/src/test/java/com/kenticocloud/delivery/DocsExamplesTest.java
@@ -53,11 +53,8 @@ public class DocsExamplesTest extends LocalServerTestBase {
         HttpHost httpHost = this.start();
         DeliveryClient client = new DeliveryClient(projectId);
 
-        //modify default baseurl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         List<NameValuePair> params = DeliveryParameterBuilder.params().language("es-ES").build();
 
@@ -79,11 +76,8 @@ public class DocsExamplesTest extends LocalServerTestBase {
         HttpHost httpHost = this.start();
         DeliveryClient client = new DeliveryClient(projectId);
 
-        //modify default baseurl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         List<NameValuePair> params = DeliveryParameterBuilder.params()
             .filterEquals("system.type", "article")
@@ -112,11 +106,8 @@ public class DocsExamplesTest extends LocalServerTestBase {
         HttpHost httpHost = this.start();
         DeliveryClient client = new DeliveryClient(projectId);
 
-        //modify default baseurl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         List<NameValuePair> params = DeliveryParameterBuilder.params().projection("title", "summary", "post_date", "teaser_image", "related_articles").build();
 
@@ -138,11 +129,8 @@ public class DocsExamplesTest extends LocalServerTestBase {
         HttpHost httpHost = this.start();
         DeliveryClient client = new DeliveryClient(projectId);
 
-        //modify default baseurl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         List<NameValuePair> params = DeliveryParameterBuilder.params().page(null, 3).build();
         ContentTypesListingResponse types = client.getTypes(params);
@@ -164,11 +152,8 @@ public class DocsExamplesTest extends LocalServerTestBase {
         HttpHost httpHost = this.start();
         DeliveryClient client = new DeliveryClient(projectId);
 
-        //modify default baseurl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         ContentType type = client.getType("coffee");
         Assert.assertNotNull(type);
@@ -188,11 +173,8 @@ public class DocsExamplesTest extends LocalServerTestBase {
         HttpHost httpHost = this.start();
         DeliveryClient client = new DeliveryClient(projectId);
 
-        //modify default baseurl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         Element element = client.getContentTypeElement("coffee", "processing");
         Assert.assertNotNull(element);
@@ -214,11 +196,8 @@ public class DocsExamplesTest extends LocalServerTestBase {
         HttpHost httpHost = this.start();
         DeliveryClient client = new DeliveryClient(projectId);
 
-        //modify default baseurl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         List<NameValuePair> params = DeliveryParameterBuilder.params().page(null, 3).build();
 
@@ -241,11 +220,8 @@ public class DocsExamplesTest extends LocalServerTestBase {
         HttpHost httpHost = this.start();
         DeliveryClient client = new DeliveryClient(projectId);
 
-        //modify default baseurl to point to test server, this is private so using reflection
-        String testServerUri = httpHost.toURI() + "/%s";
-        Field deliveryOptionsField = client.getClass().getDeclaredField("deliveryOptions");
-        deliveryOptionsField.setAccessible(true);
-        ((DeliveryOptions) deliveryOptionsField.get(client)).setProductionEndpoint(testServerUri);
+        String testServerUri = httpHost.toURI();
+        client.getDeliveryOptions().setProductionEndpoint(testServerUri);
 
         TaxonomyGroup taxonomyGroup = client.getTaxonomyGroup("personas");
         Assert.assertNotNull(taxonomyGroup);


### PR DESCRIPTION
### Motivation

Which issue does this fix? Fixes #67 

This PR allows the client to be used in a non-blocking way.
Which is a better fit with reactive frameworks like [Vert.X](https://vertx.io/) and [Micronaut](http://micronaut.io/).

I introduced a new class called `AsyncDeliveryClient`. It makes use of the [Async HTTP Client](https://github.com/AsyncHttpClient/async-http-client) and [RxJava2](https://github.com/ReativeX/RxJava).

Because the code strongly depended on the Apache HTTP client, I initially tried to use [RxApacheHttp](https://github.com/ReactiveX/RxApacheHttp). But it is outdated, and I therefore went with the libraries mentioned before.

Basically I moved the business logic from `DeliveryClient` to `AsyncDeliveryClient` and made `DeliveryClient` wrap `AsyncDeliveryClient`. From a usage perspective the `DeliveryClient` doesn't change, it remains the original blocking implementation.

I introduced an `AsyncCacheManager` accordingly.
While working on that I decided to refactor the interface a bit.
The reason for doing so is that in my opinion a cache implementation should not be responsible for performing the HTTP request and analyzing it. Instead the client should simply tell the `CacheManager` when and what it should cache.

The code is fully functional. But there are four things I still have to do:
- Create the JavaDoc in `AsyncDeliveryClient`
- Create the JavaDoc in `AsyncCacheManager`
- Configure the max http connections (originally these were set to 20)
- Extend `README.md` with an example of how to use the non-blocking client

### Checklist

- [ ❓] Code follows coding conventions held in this repo
- [ ✔] Automated tests have been added
- [ ✔] Tests are passing
- [ ❌] Docu has been updated (if applicable)
- [ ✔] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults

### How to test

Run the Unit tests