### PR TITLE
Improved inline modular content object element parsing.

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+delivery-sdk-java

--- a/build.gradle
+++ b/build.gradle
@@ -23,5 +23,5 @@
  */
 
 subprojects { project ->
-    version '2.0.2-SNAPSHOT'
+    version '2.0.2'
 }

--- a/delivery/src/main/java/com/kenticocloud/delivery/RichTextElementConverter.java
+++ b/delivery/src/main/java/com/kenticocloud/delivery/RichTextElementConverter.java
@@ -68,38 +68,8 @@ public class RichTextElementConverter {
     */
     private Pattern linkPattern = Pattern.compile("<a[^>]+?data-item-id=\"(?<id>[^\"]+)\"[^>]*>");
 
-    /*
-    Regex prior to the Java \ escapes:
-    <object type=\"application\/kenticocloud" data-type=\"(?<type>[^\"]+\") data-codename=\"(?<codename>[^\"]+\")><\/object>
-
-    Regex explanation:
-    <object type= matches the characters <object type= literally (case sensitive)
-    \" matches the character " literally (case sensitive)
-    application matches the characters application literally (case sensitive)
-    \/ matches the character / literally (case sensitive)
-    kenticocloud" data-type= matches the characters kenticocloud" data-type= literally (case sensitive)
-    \" matches the character " literally (case sensitive)
-        Named Capture Group type (?<type>[^\"]+\")
-            Match a single character not present in the list below [^\"]+
-                + Quantifier — Matches between one and unlimited times, as many times as possible, giving back as needed (greedy)
-                \" matches the character " literally (case sensitive)
-    \" matches the character " literally (case sensitive)
-     data-codename= matches the characters  data-codename= literally (case sensitive)
-    \" matches the character " literally (case sensitive)
-        Named Capture Group codename (?<codename>[^\"]+\")
-            Match a single character not present in the list below [^\"]+
-                + Quantifier — Matches between one and unlimited times, as many times as possible, giving back as needed (greedy)
-                \" matches the character " literally (case sensitive)
-    \" matches the character " literally (case sensitive)
-    >< matches the characters >< literally (case sensitive)\/ matches the character / literally (case sensitive)
-    object> matches the characters object> literally (case sensitive)
-        Global pattern flags
-            g modifier: global. All matches (don't return after first match)
-     */
-    private Pattern modularContentPattern = Pattern.compile(
-            "<object type=\"application/kenticocloud\" data-type=\"" +
-                    "(?<type>[^\"]+)\" data-codename=\"" +
-                    "(?<codename>[^\"]+)\"></object>");
+    private Pattern modularContentPattern = Pattern.compile("<object type=\"application/kenticocloud\" " +
+            "(?<attrs>[^>]+)></object>");
 
     public RichTextElementConverter(
             ContentLinkUrlResolver contentLinkUrlResolver,
@@ -179,7 +149,9 @@ public class RichTextElementConverter {
         StringBuffer buffer = new StringBuffer();
 
         while (matcher.find()) {
-            String codename = matcher.group("codename");
+            String attrs = matcher.group("attrs");
+            InlineModularContentDataAttributes dataAttributes = InlineModularContentDataAttributes.fromAttrs(attrs);
+            String codename = dataAttributes.getCodename();
             ContentItem modularContent = element.getParent().getModularContent(codename);
             InternalInlineContentItemResolver resolver = null;
             //Check to see if we encountered a cycle in our tree, if so, halt resolution
@@ -259,5 +231,38 @@ public class RichTextElementConverter {
 
     private interface InternalInlineContentItemResolver {
         String resolve();
+    }
+
+    @lombok.Getter
+    @lombok.Setter
+    @lombok.Builder
+    private static class InlineModularContentDataAttributes {
+        private static Pattern DATA_ATTRIBUTE_PATTERN = Pattern.compile("(data-\\w+)=\"(\\w+)\"");
+
+        private String type;
+        private String rel;
+        private String codename;
+
+        private static InlineModularContentDataAttributes fromAttrs(String attrs) {
+            Matcher matcher = DATA_ATTRIBUTE_PATTERN.matcher(attrs);
+            InlineModularContentDataAttributesBuilder builder = InlineModularContentDataAttributes.builder();
+            while (matcher.find()) {
+                String key = matcher.group(1);
+                String value = matcher.group(2);
+                switch (key) {
+                    case "data-type":
+                        builder.type(value);
+                        break;
+                    case "data-rel":
+                        builder.rel(value);
+                        break;
+                    case "data-codename":
+                        builder.codename(value);
+                    default:
+                        break;
+                }
+            }
+            return builder.build();
+        }
     }
 }


### PR DESCRIPTION
This update more loosely couples the contract for <object> tags in
inline modular content by ignoring attribute counts and order.

Fixes #73

### Motivation

Which issue does this fix? Fixes #73 

### Checklist

- [X] Code follows coding conventions held in this repo
- [X] Automated tests have been added
- [X] Tests are passing
- [X] Docu has been updated (if applicable)
- [X] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults

### How to test

Unit tests added provide edge case coverage.